### PR TITLE
Add low battery status for ruuvitag

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -665,6 +665,7 @@ class generic_status(Enum):
     SHORT_CIRCUITED = 2
     REVERSE_POLARITY = 3
     UNKNOWN = 4
+    SENSOR_BATTERY_LOW = 5
 
 tank_registers = {
     "tank_productid": RegisterInfo(3000, UINT16),


### PR DESCRIPTION
Ruuvitag low battery status is missing, also not on victron modbus-tcp register list